### PR TITLE
Allow the sandbox to be enabled from the constructor

### DIFF
--- a/src/Cleeng/Api.php
+++ b/src/Cleeng/Api.php
@@ -301,6 +301,10 @@ class Cleeng_Api
      */
     public function __construct($options = array())
     {
+        if (array_key_exists('enableSandbox', $options) && $options['enableSandbox'] == true) {
+            $this->enableSandbox();
+        }
+
         foreach ($options as $name => $value) {
             $methodName = 'set' . ucfirst($name);
             if (method_exists($this, $methodName)) {


### PR DESCRIPTION
So that I am able to create parameterised Symfony service definitions, I have added some code to check for a sandbox key when the API object is being constructed. This allows me to write a service definition as follows:

    cleeng_api:
        class: \Cleeng_Api
        arguments: 
            - { sandbox: %cleeng.enable_sandbox% }

This means that the service definition doesn't need to be changed between environments and relies on environment specific parameters instead.